### PR TITLE
Fix for losing expiry date/time as provided by auth

### DIFF
--- a/src/Http/FormAuthentication.php
+++ b/src/Http/FormAuthentication.php
@@ -113,6 +113,7 @@ class FormAuthentication implements ServiceModuleInterface, BeforeHookInterface
                 $this->session->regenerate();
                 $this->session->set('_form_auth_user', $userInfo->getUserId());
                 $this->session->set('_form_auth_permission_list', serialize($permissionList));
+                $this->session->set('_form_auth_session_expires_at', serialize($userInfo->getSessionExpiresAt()));
 
                 return new RedirectResponse($redirectTo, 302);
             }
@@ -134,10 +135,16 @@ class FormAuthentication implements ServiceModuleInterface, BeforeHookInterface
                 $permissionList = unserialize($sessionValue);
             }
 
-            return new UserInfo(
+            $userInfo = new UserInfo(
                 $authUser,
                 $permissionList
             );
+            if (null !== $sessionExpiresAt = $this->session->get('_form_auth_session_expires_at')) {
+                $dateTime = unserialize($sessionExpiresAt);
+                $userInfo->setSessionExpiresAt(unserialize($sessionExpiresAt));
+            }
+
+            return $userInfo;
         }
 
         // any other URL, enforce authentication

--- a/tests/Http/FormAuthenticationTest.php
+++ b/tests/Http/FormAuthenticationTest.php
@@ -106,6 +106,7 @@ class FormAuthenticationTest extends TestCase
 
         $response = $service->run($request);
         $this->assertSame('foo', $session->get('_form_auth_user'));
+        $this->assertSame(serialize(null), $session->get('_form_auth_session_expires_at'));
         $this->assertSame(302, $response->getStatusCode());
     }
 


### PR DESCRIPTION
Pass on a session expiry date/time as provided by the authentication handler via the produced UserInfo object.

The current code carries the expiry date/time along until the moment of the redirect after logging in. At that point the info is lost and the expiry date/time is not used eventually for setting the certificate expiry.