### PR TITLE
Enable LDAP auth before connecting to VPN.

### DIFF
--- a/src/ProfileConfig.php
+++ b/src/ProfileConfig.php
@@ -182,6 +182,14 @@ class ProfileConfig
     }
 
     /**
+     * @return string|null
+     */
+    public function ldapAuthPlugin()
+    {
+        return $this->config->optionalString('ldapAuthPlugin');
+    }
+
+    /**
      * @return bool
      */
     public function tlsOneThree()


### PR DESCRIPTION
This resolves issue eduvpn/vpn-user-portal#182
To be merged with https://github.com/eduvpn/vpn-server-node/pull/52 and https://github.com/eduvpn/vpn-user-portal/pull/190